### PR TITLE
Performance

### DIFF
--- a/index.js
+++ b/index.js
@@ -162,6 +162,8 @@ function getNpmLicenses() {
                             licenseText: derivedProps.licenseText
                         };
                     });
+            }, {
+                concurrency: os.cpus().length
             });
         });
 }
@@ -259,6 +261,8 @@ function getBowerLicenses() {
                             licenseText: licenseText
                         };
                     });
+            }, {
+                concurrency: os.cpus().length
             });
         });
 }

--- a/index.js
+++ b/index.js
@@ -118,9 +118,17 @@ function getNpmLicenses() {
             return bluebird.map(keys, (key) => {
                 console.log('processing', key);
                 var package = result[key];
-                return jetpack.findAsync(package['dir'], {
-                    matching: `**/node_modules/${package.name}/package.json`
-                })
+                var defaultPackagePath = `${package['dir']}/node_modules/${package.name}/package.json`
+                return jetpack.existsAsync(defaultPackagePath)
+                    .then(itemAtPath => {
+                        if (itemAtPath === 'file') {
+                            return [defaultPackagePath]
+                        } else {
+                            return jetpack.findAsync(package['dir'], {
+                                matching: `**/node_modules/${package.name}/package.json`
+                            })
+                        }
+                    })
                     .then(packagePath => {
                         if (packagePath && packagePath[0]) {
                             return jetpack.read(packagePath[0], 'json');


### PR DESCRIPTION
Addresses #5.

- Limit bluebird `Promise.map` calls to spawning no more concurrent processes than the number of logical CPUs
    - Should reduce context switching overhead
    - Users see gradual progress rather than a long wait state
- Skip an expensive jetpack `findAsync` call made once per package when the package file is at an obvious default path
    - This call was the performance bottleneck in the npm packages code path
    - It'd be nice to find a way to accomplish the goal without ever using this method