### PR TITLE
AIA-16918: Strip out several dependencies to avoid current and future audit failures

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 // usage
 var yargs = require('yargs')
-    .usage('Calculate the npm and bower modules used in this project and generate a third-party attribution (credits) text.',
+    .usage('Calculate the npm modules used in this project and generate a third-party attribution (credits) text.',
     {
         outputDir: {
             alias: 'o',
@@ -24,15 +24,16 @@ if (yargs.argv.help) {
 }
 
 // dependencies
-var bluebird = require('bluebird');
-var _ = require('lodash');
-var npmchecker = require('license-checker');
-var bower = require('bower');
+var npmChecker = require('license-checker');
 var path = require('path');
 var jetpack = require('fs-jetpack');
 var cp = require('child_process');
 var os = require('os');
 var taim = require('taim');
+var sortBy = require('lodash.sortby');
+var {promisify} = require('util');
+
+var npmCheckerInit = promisify(npmChecker.init);
 
 // const
 var licenseCheckerCustomFormat = {
@@ -52,10 +53,10 @@ var licenseCheckerCustomFormat = {
  * Helpers
  */
 function getAttributionForAuthor(a) {
-    return _.isString(a) ? a : a.name + ((a.email || a.homepage || a.url) ? ` <${a.email || a.homepage || a.url}>` : '');
+    return typeof a === 'string' ? a : a.name + ((a.email || a.homepage || a.url) ? ` <${a.email || a.homepage || a.url}>` : '');
 }
 
-function getNpmLicenses() {
+async function getNpmLicenses() {
     var npmDirs;
     if (!Array.isArray(options.baseDir)) {
         npmDirs = [options.baseDir];
@@ -70,36 +71,26 @@ function getNpmLicenses() {
         }
     }
     console.log('Looking at directories: ' + npmDirs)
-
     var res = []
     var checkers = [];
+
     for (var i = 0; i < npmDirs.length; i++) {
-        checkers.push(
-            bluebird.fromCallback((cb) => {
-                var dir = npmDirs[i];
-                return npmchecker.init({
-                    start: npmDirs[i],
-                    production: true,
-                    customFormat: licenseCheckerCustomFormat
-                }, function (err, json) {
-                    if (err) {
-                        //Handle error
-                        console.error(err);
-                    } else {
-                        Object.getOwnPropertyNames(json).forEach(k => {
-                            json[k]['dir'] = dir;
-                        })
-                    }
-                    cb(err, json);
-                });
-            })
-        );
+        var dir = npmDirs[i];
+        const checker = await npmCheckerInit({
+            start: npmDirs[i],
+            production: true,
+            customFormat: licenseCheckerCustomFormat
+        });
+        Object.getOwnPropertyNames(checker).forEach(k => {
+            checker[k]['dir'] = dir;
+        })
+        checkers.push(checker);
     }
     if (checkers.length === 0) {
         return [];
     }
 
-    return bluebird.all(checkers)
+    return Promise.all(checkers)
         .then((raw_result) => {
             // the result is passed in as an array, one element per npmDir passed in
             // de-dupe the entries and merge it into a single object
@@ -116,8 +107,9 @@ function getNpmLicenses() {
             var keys = Object.getOwnPropertyNames(result).filter((k) => {
                 return k !== `${topLevelProjectInfo.name}@${topLevelProjectInfo.version}`;
             });
+            const finalResult = [];
 
-            return bluebird.map(keys, (key) => {
+            const promises = keys.map((key) => {
                 console.log('processing', key);
 
                 var package = result[key];
@@ -187,118 +179,10 @@ function getNpmLicenses() {
             }, {
                 concurrency: os.cpus().length
             });
+            return Promise.all(promises);
         });
 }
 
-/**
- * TL;DR - normalizing the output format for NPM & Bower license info
- *
- * The output from license-checker gives us what we need:
- *  - component name
- *  - version
- *  - authors (note: not returned by license-checker, we have to apply our heuristic)
- *  - url
- *  - license(s)
- *  - license contents OR license snippet (in case of license embedded in markdown)
- *
- * Where we calculate the license information manually for Bower components,
- * we'll return an object with these properties.
- */
-function getBowerLicenses() {
-    // first - check that this is even a bower project
-    var baseDir;
-    if (Array.isArray(options.baseDir)) {
-        baseDir = options.baseDir[0];
-        if (options.baseDir.length > 1) {
-            console.warn("Checking multiple directories is not yet supported for Bower projects.\n" +
-                "Checking only the first directory: " + baseDir);
-        }
-    }
-    if (!jetpack.exists(path.join(baseDir, 'bower.json'))) {
-        console.log('this does not look like a Bower project, skipping Bower checks.');
-        return [];
-    }
-
-    bower.config.cwd = baseDir;
-    var bowerComponentsDir = path.join(bower.config.cwd, bower.config.directory);
-    return jetpack.inspectTreeAsync(bowerComponentsDir, { relativePath: true })
-        .then((result) => {
-            /**
-             * for each component, try to calculate the license from the NPM package info
-             * if it is a available because license-checker more closely aligns with our
-             * objective.
-             */
-            return bluebird.map(result.children, (component) => {
-                var absPath = path.join(bowerComponentsDir, component.relativePath);
-                // npm license check didn't work
-                // try to get the license and package info from .bower.json first
-                // because it has more metadata than the plain bower.json
-      
-                var package = '';
-      
-                try {
-                  package = jetpack.read(path.join(absPath, '.bower.json'), 'json');
-                } catch (e) {
-                  package = jetpack.read(path.join(absPath, 'bower.json'), 'json');
-                }
-      
-                console.log('processing', package.name);
-                // assumptions here based on https://github.com/bower/spec/blob/master/json.md
-                // extract necessary properties as described in TL;DR above
-                var url = package["_source"] || (package.repository && package.repository.url) ||
-                  package.url || package.homepage;
-      
-                var authors = '';
-
-                if (package.authors) {
-                  authors = _.map(package.authors, a => {
-                    return getAttributionForAuthor(a);
-                  }).join(', ');
-                } else {
-                  // extrapolate author from url if it's a github repository
-                  var githubMatch = url.match(/github\.com\/.*\//);
-
-                  if (githubMatch) {
-                    authors = githubMatch[0]
-                      .replace('github.com', '')
-                      .replace(/\//g, '');
-                  }
-                }
-      
-                // normalize the license object
-                package.license = package.license || package.licenses;
-
-                var licenses = package.license && _.isString(package.license)
-                    ? package.license
-                    : _.isArray(package.license)
-                      ? package.license.join(',')
-                      : package.licenses;
-      
-                // find the license file if it exists
-                var licensePath = _.find(component.children, c => {
-                  return /licen[cs]e/i.test(c.name);
-                });
-
-                var licenseText = null;
-
-                if (licensePath) {
-                  licenseText = jetpack.read(path.join(bowerComponentsDir, licensePath.relativePath));
-                }
-      
-                return {
-                  ignore: false,
-                  name: package.name,
-                  version: package.version || package['_release'],
-                  authors: authors,
-                  url: url,
-                  license: licenses,
-                  licenseText: licenseText
-                };
-            }, {
-                concurrency: os.cpus().length
-            });
-        });
-}
 
 /***********************
  *
@@ -317,45 +201,22 @@ for (var i = 0; i < yargs.argv.baseDir.length; i++) {
 }
 
 
-taim('Total Processing', bluebird.all([
+taim('Total Processing', 
     taim('Npm Licenses', getNpmLicenses()),
-    getBowerLicenses()
-]))
+)
     .catch((err) => {
         console.log(err);
         process.exit(1);
     })
-    .spread((npmOutput, bowerOutput) => {
-        var o = {};
-        npmOutput = npmOutput || {};
-        bowerOutput = bowerOutput || {};
-        _.concat(npmOutput, bowerOutput).forEach((v) => {
-            o[v.name] = v;
-        });
-
-        var userOverridesPath = path.join(options.outputDir, 'overrides.json');
-        if (jetpack.exists(userOverridesPath)) {
-            var userOverrides = jetpack.read(userOverridesPath, 'json');
-            console.log('using overrides:', userOverrides);
-            // foreach override, loop through the properties and assign them to the base object.
-            o = _.defaultsDeep(userOverrides, o);
-        }
-
-        return o;
-    })
-    .catch(e => {
-        console.error('ERROR processing overrides', e);
-        process.exit(1);
-    })
-    .then((licenseInfos) => {
-        var attributionSequence = _(licenseInfos).filter(licenseInfo => {
+  .then((licenseInfos) => {
+      var attributionSequence = sortBy(licenseInfos, licenseInfo => licenseInof.name.toLowerCase)
+        .filter(licenseInfo => {
             return !licenseInfo.ignore && licenseInfo.name != undefined;
-        }).sortBy(licenseInfo => {
-            return licenseInfo.name.toLowerCase();
-        }).map(licenseInfo => {
+        })
+        .map(licenseInfo => {
             return [licenseInfo.name,`${licenseInfo.version} <${licenseInfo.url}>`,
                     licenseInfo.licenseText || `license: ${licenseInfo.license}${os.EOL}authors: ${licenseInfo.authors}`].join(os.EOL);
-        }).value();
+        });
 
         var attribution = attributionSequence.join(`${os.EOL}${os.EOL}******************************${os.EOL}${os.EOL}`);
 

--- a/package.json
+++ b/package.json
@@ -1,21 +1,19 @@
 {
   "dependencies": {
-    "bluebird": "^3.5.0",
-    "bower": "^1.8.0",
-    "bower-json": "^0.8.1",
-    "bower-license": "^0.4.4",
     "fs-jetpack": "^0.12.0",
     "license-checker": "^13.0.3",
-    "lodash": "^4.17.4",
-    "spdx-licenses": "^0.0.3",
-    "yargs": "^7.0.2",
-    "taim": "^1.0.2"
+    "lodash.sortby": "^4.7.0",
+    "taim": "^1.0.2",
+    "yargs": "^7.0.2"
   },
   "name": "oss-attribution-generator",
   "description": "utility to parse bower and npm packages used in a project and generate an attribution file to include in your product",
   "version": "1.7.1",
   "bin": {
     "generate-attribution": "index.js"
+  },
+  "engines": {
+    "node": ">=14.0.0"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
This is a major release.

This pull request:
- drops bower module support to remove multiple dependencies
- rips out bluebird, thus requiring a higher nodejs version
- get rid of unused overrides.json feature to avoid the lodash prototype vulnerabilities
- only lodash.sortby is really worth keeping, got rid of the main lodash dependency